### PR TITLE
Improved elimination performance using neighbor lists

### DIFF
--- a/modules/algorithms/src/test/java/ffx/algorithms/RotamerOptimizationTest.java
+++ b/modules/algorithms/src/test/java/ffx/algorithms/RotamerOptimizationTest.java
@@ -44,6 +44,7 @@ import java.util.Collection;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import ffx.potential.Utilities;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -432,7 +433,12 @@ public class RotamerOptimizationTest extends PJDependentTest {
         if (doOverallOpt) {
             rotamerOptimization.turnRotamerPairEliminationOff();
             rotamerOptimization.setTestOverallOpt(true);
-            energy = rotamerOptimization.optimize(RotamerOptimization.Algorithm.ALL);
+            try {
+                energy = rotamerOptimization.optimize(RotamerOptimization.Algorithm.ALL);
+            } catch (Exception e) {
+                logger.warning(Utilities.stackTraceToString(e));
+                throw e;
+            }
             //System.out.println("The expected overall energy is: " + energy);
             assertEquals(info + " Total Energy", expectedEnergy, energy, tolerance);
         }
@@ -728,7 +734,12 @@ public class RotamerOptimizationTest extends PJDependentTest {
         int nRes = residueList.size();
         if (doOverallOpt) {
             rotamerOptimization.turnRotamerSingleEliminationOff();
-            energy = rotamerOptimization.optimize(RotamerOptimization.Algorithm.ALL);
+            try {
+                energy = rotamerOptimization.optimize(RotamerOptimization.Algorithm.ALL);
+            } catch (Exception e) {
+                logger.warning(Utilities.stackTraceToString(e));
+                throw e;
+            }
             //System.out.println("The expected overall energy is: " + energy);
             assertEquals(info + " Total Energy", expectedEnergy, energy, tolerance);
         }


### PR DESCRIPTION
This pull request improves DEE/Goldstein elimination performance. While the 3-body energies map was to some extent a good idea, it does not perform adequately when many 3-body energies are required for eliminations. Each map access is likely costing us on the order of 2 microseconds, where array accesses are generally nanoseconds, thanks to being much easier to predict and pre-load into cache.

Furthermore, the eliminations themselves are greatly sped up using similar neighbor lists, by not considering residues outside the neighbor lists in the elimination math, for the pair and triple energies are guaranteed to be zero. This appears to finish restoring elimination performance to acceptable levels.