### PR TITLE
Fixes to rotamer optimization

### DIFF
--- a/modules/algorithms/src/main/java/ffx/algorithms/RotamerOptimization.java
+++ b/modules/algorithms/src/main/java/ffx/algorithms/RotamerOptimization.java
@@ -991,11 +991,13 @@ public class RotamerOptimization implements Terminatable {
 
         prop = System.getProperty("ro-singularityThreshold");
         double singT = DEFAULT_SINGULARITY_THRESHOLD;
-        try {
-            singT = Double.parseDouble(prop);
-        } catch (Exception ex) {
-            logger.warning(String.format(" Exception in parsing ro-singularityThreshold: %s", ex));
-            singT = DEFAULT_SINGULARITY_THRESHOLD;
+        if (prop != null) {
+            try {
+                singT = Double.parseDouble(prop);
+            } catch (Exception ex) {
+                logger.warning(String.format(" Exception in parsing ro-singularityThreshold: %s", ex));
+                singT = DEFAULT_SINGULARITY_THRESHOLD;
+            }
         }
         singularityThreshold = singT;
         potentialIsOpenMM = potential instanceof ForceFieldEnergyOpenMM;
@@ -6749,18 +6751,15 @@ public class RotamerOptimization implements Terminatable {
     }
 
     private int eliminateRotamerPairs(Residue[] residues, int i, int ri, boolean verbose) {
-        int nres = residues.length;
+        int nNeighbors = resNeighbors[i].length;
         int eliminatedPairs = 0;
-        for (int j = 0; j < nres; j++) {
-            if (j == i) {
-                continue;
-            }
-            Residue residuej = residues[j];
-            Rotamer rotamersj[] = residuej.getRotamers(library);
-            int lenrj = rotamersj.length;
+        for (int indJ = 0; indJ < nNeighbors; indJ++) {
+            int j = resNeighbors[i][indJ];
+            Residue resj = residues[j];
+            int lenrj = resj.getRotamers(library).length;
             for (int rj = 0; rj < lenrj; rj++) {
                 if (eliminateRotamerPair(residues, i, ri, j, rj, verbose)) {
-                    eliminatedPairs++;
+                    ++eliminatedPairs;
                 }
             }
         }

--- a/modules/algorithms/src/main/java/ffx/algorithms/RotamerOptimization.java
+++ b/modules/algorithms/src/main/java/ffx/algorithms/RotamerOptimization.java
@@ -6808,13 +6808,8 @@ public class RotamerOptimization implements Terminatable {
             Residue resj = residues[j];
             int lenrj = resj.getRotamers(library).length;
             for (int rj = 0; rj < lenrj; rj++) {
-                try {
-                    if (eliminateRotamerPair(residues, i, ri, j, rj, verbose)) {
-                        ++eliminatedPairs;
-                    }
-                } catch (ArrayIndexOutOfBoundsException aie) {
-                    logger.info(String.format(" Attempted to eliminate %s(%d)-%d %s(%d)-%d", residues[i], i, ri, residues[j], j, rj));
-                    throw aie;
+                if (eliminateRotamerPair(residues, i, ri, j, rj, verbose)) {
+                    ++eliminatedPairs;
                 }
             }
         }
@@ -7513,23 +7508,6 @@ public class RotamerOptimization implements Terminatable {
             ri = rj;
             j = ii;
             rj = iri;
-        }
-        if (i >= eliminatedPairs.length) {
-            logger.info(String.format(" i %d >= length %d", i, eliminatedPairs.length));
-        }
-        if (j >= eliminatedPairs.length) {
-            logger.info(String.format(" j %d >= length %d", j, eliminatedPairs.length));
-        }
-        if (eliminatedPairs[i] == null) {
-            logger.info(" elim pairs i == null");
-        } else if (ri >= eliminatedPairs[i].length) {
-            logger.info(String.format(" ri %d >= elimPairsI length %d", ri, eliminatedPairs[i].length));
-        } else if (eliminatedPairs[i][ri] == null) {
-            logger.info(" elim pairs i,ri == null");
-        } else if (eliminatedPairs[i][ri][j] == null) {
-            logger.info(" elim pairs i,ri,j == null");
-        } else if (rj >= eliminatedPairs[i][ri][j].length) {
-            logger.info(String.format(" rj %d >= elimPairsI,RI,J length %d", rj, eliminatedPairs[i][ri][j].length));
         }
         return eliminatedPairs[i][ri][j][rj];
     }

--- a/modules/algorithms/src/main/java/ffx/algorithms/RotamerOptimization.java
+++ b/modules/algorithms/src/main/java/ffx/algorithms/RotamerOptimization.java
@@ -6800,10 +6800,11 @@ public class RotamerOptimization implements Terminatable {
     }
 
     private int eliminateRotamerPairs(Residue[] residues, int i, int ri, boolean verbose) {
-        int nNeighbors = resNeighbors[i].length;
         int eliminatedPairs = 0;
-        for (int indJ = 0; indJ < nNeighbors; indJ++) {
-            int j = resNeighbors[i][indJ];
+        for (int j = 0; j < residues.length; j++) {
+            if (j == i) {
+                continue;
+            }
             Residue resj = residues[j];
             int lenrj = resj.getRotamers(library).length;
             for (int rj = 0; rj < lenrj; rj++) {

--- a/modules/potential/src/main/java/ffx/potential/ForceFieldEnergyOpenMM.java
+++ b/modules/potential/src/main/java/ffx/potential/ForceFieldEnergyOpenMM.java
@@ -1624,7 +1624,7 @@ public class ForceFieldEnergyOpenMM extends ForceFieldEnergy {
             logger.info(format(" VDW Type:         %s", vdwForm.vdwType));
             logger.info(format(" VDW Radius Rule:  %s", vdwForm.radiusRule));
             logger.info(format(" VDW Epsilon Rule: %s", vdwForm.epsilonRule));
-            logger.log(Level.SEVERE, String.format(" Unsupported van der Waals functional form."));
+            logger.log(Level.SEVERE, " Unsupported van der Waals functional form.");
             return;
         }
 

--- a/modules/potential/src/main/java/ffx/potential/ForceFieldEnergyOpenMM.java
+++ b/modules/potential/src/main/java/ffx/potential/ForceFieldEnergyOpenMM.java
@@ -3200,6 +3200,18 @@ public class ForceFieldEnergyOpenMM extends ForceFieldEnergy {
     }
 
     /**
+     * Evaluates energy explicitly using the Java implementation backing this
+     * ForceFieldEnergyOpenMM.
+     *
+     * @param x       Coordinate array
+     * @param verbose Verbosity of energy call
+     * @return        Total energy calculated by reference FFX implementation.
+     */
+    public double ffxEnergy(double[] x, boolean verbose) {
+        return super.energy(x, verbose);
+    }
+
+    /**
      * Evaluates energy and gradients both with OpenMM and reference potential,
      * and returns the difference FFX-OpenMM.
      *


### PR DESCRIPTION
This pull request fixes some issues with rotamer optimization; incorrect rotamer pair eliminations for window/box optimizations (but probably not global), and suspiciously low energies from OpenMM are re-calculated under the FFX reference implementation (by default, ro-ommRecalculateThreshold is -200 kcal/mol).

Three further changes are suggested:
1) Setting DEFAULT_SINGULARITY_THRESHOLD to a very large negative number. That mechanic (by which very low energies are outright rejected) is definitely a heuristic.
2) Replacing the behavior of singularityThreshold, simply printing out a PDB instead of rejecting the energy.
3) Setting overlapThreshold to a larger value, possibly 0.25-0.5 Angstroms.