### PR TITLE
Reduced verbosity of several alchemical atom printouts

### DIFF
--- a/modules/algorithms/src/main/java/ffx/algorithms/GenerateRotamers.java
+++ b/modules/algorithms/src/main/java/ffx/algorithms/GenerateRotamers.java
@@ -42,6 +42,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -267,7 +268,7 @@ public class GenerateRotamers {
                     for (int i = begin; i <= end; i++) {
                         Atom ai = atoms[i - 1];
                         ai.setElectrostatics(false);
-                        ai.print();
+                        ai.print(Level.FINE);
                     }
                 } else {
                     logger.info(String.format(" Discarding electrostatics input %s", tok));
@@ -294,7 +295,7 @@ public class GenerateRotamers {
                     for (int i = begin; i <= end; i++) {
                         Atom ai = atoms[i - 1];
                         ai.setUse(false);
-                        ai.print();
+                        ai.print(Level.FINE);
                     }
                 } else {
                     logger.info(String.format(" Discarding inactive atoms input %s", tok));

--- a/modules/potential/src/main/groovy/ffx/potential/groovy/Energy.groovy
+++ b/modules/potential/src/main/groovy/ffx/potential/groovy/Energy.groovy
@@ -82,10 +82,13 @@ class Energy extends PotentialScript {
         int noElecStop = ef1
         noElecStop = (noElecStop > atoms.length) ? atoms.length : noElecStop
 
+        if (noElecStart <= noElecStop) {
+            logger.info(String.format(" Disabling electrostatics for atoms %d (%s) to %d (%s).", noElecStart, atoms[noElecStart - 1], noElecStop, atoms[noElecStop - 1]))
+        }
         for (int i = noElecStart; i <= noElecStop; i++) {
             Atom ai = atoms[i - 1]
             ai.setElectrostatics(false)
-            ai.print()
+            ai.print(java.util.logging.Level.FINE)
         }
 
         int nVars = forceFieldEnergy.getNumberOfVariables()

--- a/modules/potential/src/main/java/ffx/potential/ForceFieldEnergy.java
+++ b/modules/potential/src/main/java/ffx/potential/ForceFieldEnergy.java
@@ -2592,6 +2592,7 @@ public class ForceFieldEnergy implements CrystalPotential, LambdaInterface {
      */
     @Override
     public double energy(double[] x, boolean verbose) {
+        assert Arrays.stream(x).allMatch(Double::isFinite);
         /**
          * Unscale the coordinates.
          */

--- a/modules/potential/src/main/java/ffx/potential/bonded/Atom.java
+++ b/modules/potential/src/main/java/ffx/potential/bonded/Atom.java
@@ -57,6 +57,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import static java.lang.String.format;
 
@@ -1719,7 +1720,11 @@ public class Atom extends MSNode implements Comparable<Atom> {
      */
     @Override
     public final void print() {
-        logger.info(toString());
+        print(Level.INFO);
+    }
+
+    public final void print(Level logLevel) {
+        logger.log(logLevel, toString());
     }
 
     /**

--- a/modules/potential/src/main/java/ffx/potential/cli/AlchemicalOptions.java
+++ b/modules/potential/src/main/java/ffx/potential/cli/AlchemicalOptions.java
@@ -171,10 +171,11 @@ public class AlchemicalOptions {
     public static void setAlchemicalAtoms(MolecularAssembly assembly, int start, int fin, String ligAt) {
         Atom[] atoms = assembly.getAtomArray();
         if (start > 0) {
+            logger.info(String.format(" Setting atoms %d (%s) to %d (%s) as alchemical", start, atoms[start - 1], fin, atoms[fin - 1]));
             for (int i = start; i <= fin; i++) {
                 Atom ai = atoms[i - 1];
                 ai.setApplyLambda(true);
-                ai.print();
+                ai.print(Level.FINE);
             }
         }
         if (ligAt != null) {
@@ -187,11 +188,12 @@ public class AlchemicalOptions {
                     if (rangeStart > rangeEnd) {
                         logger.severe(String.format(" Range %s was invalid; start was greater than end", range));
                     }
+                    logger.info(String.format(" Setting atoms %d (%s) to %d (%s) as alchemical", rangeStart, atoms[rangeStart - 1], rangeEnd, atoms[rangeEnd - 1]));
                     // Don't need to worry about negative numbers; rangeregex just won't match.
                     for (int i = rangeStart; i <= rangeEnd; i++) {
                         Atom ai = atoms[i - 1];
                         ai.setApplyLambda(true);
-                        ai.print();
+                        ai.print(Level.FINE);
                     }
                 } else {
                     logger.warning(String.format(" Could not recognize %s as a valid range; skipping", range));

--- a/modules/potential/src/main/java/ffx/potential/nonbonded/ParticleMeshEwaldCart.java
+++ b/modules/potential/src/main/java/ffx/potential/nonbonded/ParticleMeshEwaldCart.java
@@ -40,6 +40,8 @@ package ffx.potential.nonbonded;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.IntStream;
+
 import static java.lang.String.format;
 import static java.util.Arrays.copyOf;
 import static java.util.Arrays.fill;
@@ -84,6 +86,8 @@ import ffx.potential.parameters.ForceField.ForceFieldType;
 import ffx.potential.parameters.MultipoleType;
 import ffx.potential.parameters.PolarizeType;
 import ffx.potential.utils.EnergyException;
+import ffx.utilities.StringUtils;
+
 import static ffx.numerics.math.VectorMath.cross;
 import static ffx.numerics.math.VectorMath.diff;
 import static ffx.numerics.math.VectorMath.dot;
@@ -1216,7 +1220,15 @@ public class ParticleMeshEwaldCart extends ParticleMeshEwald implements LambdaIn
         }
 
         if (count > 0) {
-            logger.info(sb.toString());
+            logger.info(String.format(" Softcore atom count: %d", count));
+            int[] allSoftcore = IntStream.range(0, nAtoms).filter(i -> isSoft[i]).toArray();
+            List<int[]> softcoreRanges = StringUtils.consecutiveInts(allSoftcore);
+            for (int[] range : softcoreRanges) {
+                int min = range[0];
+                int max = range[1];
+                logger.info(String.format(" Softcore range %d (%s) to %d (%s)", min + 1, atoms[min], max + 1, atoms[max]));
+            }
+            logger.fine(sb.toString());
         }
 
         /**

--- a/modules/utilities/src/main/java/ffx/utilities/StringUtils.java
+++ b/modules/utilities/src/main/java/ffx/utilities/StringUtils.java
@@ -51,6 +51,9 @@ import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.io.Writer;
 import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
@@ -296,6 +299,36 @@ public class StringUtils {
         }
 
         return tmpFile.toString();
+    }
+
+    /**
+     * Finds consecutive subranges in an array of ints, and returns their mins
+     * and maxes. This can include singletons.
+     *
+     * Example: [4, 5, 6, 1, 1, 2, 5, 6, 7] would become [4,6],[1,1],[1,2],[5,7]
+     *
+     * @param set Array of ints to split into consecutive subranges.
+     * @return Consecutive subrange mins, maxes
+     */
+    public static List<int[]> consecutiveInts(int[] set) {
+        if (set == null || set.length == 0) {
+            return Collections.emptyList();
+        }
+        List<int[]> allRanges = new ArrayList<>();
+
+        int rangeStart = set[0];
+        int rangeEnd = rangeStart;
+        for (int i = 1; i < set.length; i++) {
+            if (set[i] == rangeEnd + 1) {
+                rangeEnd = set[i];
+            } else {
+                allRanges.add(new int[]{rangeStart, rangeEnd});
+                rangeStart = set[i];
+                rangeEnd = rangeStart;
+            }
+        }
+        allRanges.add(new int[]{rangeStart, rangeEnd});
+        return allRanges;
     }
 
 }


### PR DESCRIPTION
This would eliminate "let's print every single alchemical atom... twice", and replace it with "let's print out the first and last atom of each alchemical range"... well, still twice, but still a lot less verbose. Full printouts are handled at the Level.FINE range. This eliminates tens of thousands of lines from our test logging.