### PR TITLE
Fixes to RestraintBond during alchemical transformation

### DIFF
--- a/modules/algorithms/src/test/java/ffx/algorithms/groovy/ThermodynamicsTest.java
+++ b/modules/algorithms/src/test/java/ffx/algorithms/groovy/ThermodynamicsTest.java
@@ -145,7 +145,7 @@ public class ThermodynamicsTest extends PJDependentTest {
                                 "ffx/algorithms/structures/4icb_mg_a.xyz", "ffx/algorithms/structures/4icb_mg_b.xyz"},
                         ThermoTestMode.GRAD, 0, 0, new int[]{1, 100, 421, 426, 919, 921, 1203, 1204, 1205, 1206, 1207, 1208},
                         // Fill in the post-bias PE and dU/dL once I have bias deposition working.
-                        new double[]{-8422.43552052, 0}, new double[]{-0.0234728644, 0}, new double[]{-187.693010, Double.NaN},
+                        new double[]{-8422.43552052, 0}, new double[]{0, 0}, new double[]{-187.708505969645246, Double.NaN},
                         new double[][][]{
                                 {{1.51602997670091, -0.16798107175016064, 1.1909011229485826},
                                         {-1.2287108493416157, 0.3317143880292477, -1.168707082997385},
@@ -185,7 +185,7 @@ public class ThermodynamicsTest extends PJDependentTest {
                                 "ffx/algorithms/structures/4icb_mg_a.xyz", "ffx/algorithms/structures/4icb_mg_b.xyz"},
                         ThermoTestMode.GRAD, 0, 0, new int[]{1, 100, 421, 426, 919, 921, 1203, 1204, 1205, 1206, 1207, 1208},
                         // Fill in the post-bias PE and dU/dL once I have bias deposition working.
-                        new double[]{-8441.45436853, 0}, new double[]{-59.7520122, 0}, new double[]{0.170957221, Double.NaN},
+                        new double[]{-8441.45436853, 0}, new double[]{-59.7520122, 0}, new double[]{0, Double.NaN},
                         new double[][][]{
                                 {{1.516028943632357, -0.16798187601812842, 1.1909000012817135},
                                         {-1.2287100421217505, 0.33171692634032457, -1.1687028725533608},
@@ -225,7 +225,7 @@ public class ThermodynamicsTest extends PJDependentTest {
                                 "ffx/algorithms/structures/4icb_mg_a.xyz", "ffx/algorithms/structures/4icb_mg_b.xyz"},
                         ThermoTestMode.GRAD, 0, 0, new int[]{1, 100, 421, 426, 919, 921, 1203, 1204, 1205, 1206, 1207, 1208},
                         // Fill in the post-bias PE and dU/dL once I have bias deposition working.
-                        new double[]{-8460.47321653, 0}, new double[]{0.0234728644, 0}, new double[]{187.739955, Double.NaN},
+                        new double[]{-8460.47321653, 0}, new double[]{0, 0}, new double[]{187.70850596942546, Double.NaN},
                         new double[][][]{
                                 {{1.5160279105638157, -0.16798268028609797, 1.1908988796148456},
                                         {-1.2287092349018947, 0.3317194646514121, -1.1686986621093438},
@@ -265,7 +265,7 @@ public class ThermodynamicsTest extends PJDependentTest {
                                 "ffx/algorithms/structures/5cpv_mg_a.xyz", "ffx/algorithms/structures/5cpv_mg_b.xyz"},
                         ThermoTestMode.GRAD, 0, 0, new int[]{1, 303, 1401, 1402, 1482, 1488, 1489, 1602, 1603, 1604, 1605, 1606},
                         // Fill in the post-bias PE and dU/dL once I have bias deposition working.
-                        new double[]{-10378.104156403408, 0}, new double[]{-0.0337450891, 0}, new double[]{-197.374818, Double.NaN},
+                        new double[]{-10378.104156403408, 0}, new double[]{0, 0}, new double[]{-197.40065865800716, Double.NaN},
                         new double[][][]{
                                 {{-1.1610229302444828,0.8877842196621852,-0.38190472079527416},
                                         {0.17141739386080523,-0.6936874602017804,-0.2646850671524603},
@@ -304,7 +304,7 @@ public class ThermodynamicsTest extends PJDependentTest {
                                 "ffx/algorithms/structures/5cpv_mg_a.xyz", "ffx/algorithms/structures/5cpv_mg_b.xyz"},
                         ThermoTestMode.GRAD, 0, 0, new int[]{1, 303, 1401, 1402, 1482, 1488, 1489, 1602, 1603, 1604, 1605, 1606},
                         // Fill in the post-bias PE and dU/dL once I have bias deposition working.
-                        new double[]{-10398.105024790417, 0}, new double[]{-62.8370972544, 0}, new double[]{0.245771737152, Double.NaN},
+                        new double[]{-10398.105024790417, 0}, new double[]{-62.8370972544, 0}, new double[]{0, Double.NaN},
                         new double[][][]{
                                 {{-1.1610220532282816,0.8877825087765396,-0.38190561321870153},
                                         {0.17141666802985345,-0.6936868435232721,-0.26468548230330735},
@@ -343,7 +343,7 @@ public class ThermodynamicsTest extends PJDependentTest {
                                 "ffx/algorithms/structures/5cpv_mg_a.xyz", "ffx/algorithms/structures/5cpv_mg_b.xyz"},
                         ThermoTestMode.GRAD, 0, 0, new int[]{1, 303, 1401, 1402, 1482, 1488, 1489, 1602, 1603, 1604, 1605, 1606},
                         // Fill in the post-bias PE and dU/dL once I have bias deposition working.
-                        new double[]{-10418.105893177431, 0}, new double[]{0.0337450891052, 0}, new double[]{197.442308197, Double.NaN},
+                        new double[]{-10418.105893177431, 0}, new double[]{0, 0}, new double[]{197.40065865800716, Double.NaN},
                         new double[][][]{
                                 {{-1.1610211762120812,0.887780797890894,-0.3819065056421289},
                                         {0.17141594219890166,-0.6936862268447639,-0.2646858974541544},

--- a/modules/numerics/src/main/java/ffx/numerics/switching/BellCurveSwitch.java
+++ b/modules/numerics/src/main/java/ffx/numerics/switching/BellCurveSwitch.java
@@ -87,7 +87,7 @@ public class BellCurveSwitch implements UnivariateSwitchingFunction {
      */
     @Override
     public boolean constantOutsideBounds() {
-        return false;
+        return switchingFunction.constantOutsideBounds() && secondSwitchingFunction.constantOutsideBounds();
     }
 
     /**
@@ -95,7 +95,7 @@ public class BellCurveSwitch implements UnivariateSwitchingFunction {
      */
     @Override
     public boolean validOutsideBounds() {
-        return false;
+        return switchingFunction.validOutsideBounds() && secondSwitchingFunction.validOutsideBounds();
     }
 
     /**
@@ -103,7 +103,7 @@ public class BellCurveSwitch implements UnivariateSwitchingFunction {
      */
     @Override
     public int getHighestOrderZeroDerivative() {
-        return 2;
+        return Math.min(switchingFunction.getHighestOrderZeroDerivative(), secondSwitchingFunction.getHighestOrderZeroDerivative());
     }
 
     /**
@@ -111,7 +111,7 @@ public class BellCurveSwitch implements UnivariateSwitchingFunction {
      */
     @Override
     public boolean symmetricToUnity() {
-        return true;
+        return switchingFunction.symmetricToUnity() && secondSwitchingFunction.symmetricToUnity();
     }
 
     /**

--- a/modules/numerics/src/main/java/ffx/numerics/switching/ConstantSwitch.java
+++ b/modules/numerics/src/main/java/ffx/numerics/switching/ConstantSwitch.java
@@ -47,14 +47,12 @@ package ffx.numerics.switching;
  */
 public class ConstantSwitch implements UnivariateSwitchingFunction {
 
-    // TODO: check on returns for getZeroBound and getOneBound
-
     /**
      * {@inheritDoc}
      */
     @Override
     public double getZeroBound() {
-        return 0;
+        return Double.NaN;
     }
 
     /**
@@ -70,7 +68,7 @@ public class ConstantSwitch implements UnivariateSwitchingFunction {
      */
     @Override
     public boolean constantOutsideBounds() {
-        return false;
+        return true;
     }
 
     /**
@@ -126,6 +124,14 @@ public class ConstantSwitch implements UnivariateSwitchingFunction {
      */
     @Override
     public double nthDerivative(double x, int order) throws IllegalArgumentException {
+        if (order < 0) {
+            throw new IllegalArgumentException(String.format(" Order must be > 0, was %d", order));
+        }
         return 0.0;
+    }
+
+    @Override
+    public String toString() {
+        return "Constant-value f(x) = 1, with no switching behavior (i.e. a dummy switch)";
     }
 }

--- a/modules/numerics/src/main/java/ffx/numerics/switching/LinearDerivativeSwitch.java
+++ b/modules/numerics/src/main/java/ffx/numerics/switching/LinearDerivativeSwitch.java
@@ -143,4 +143,9 @@ public class LinearDerivativeSwitch implements UnivariateSwitchingFunction {
                 return 0;
         }
     }
+
+    @Override
+    public String toString() {
+        return "Polynomial switch of form f(x) = 2x - x^2";
+    }
 }

--- a/modules/numerics/src/main/java/ffx/numerics/switching/PowerSwitch.java
+++ b/modules/numerics/src/main/java/ffx/numerics/switching/PowerSwitch.java
@@ -62,7 +62,7 @@ public class PowerSwitch implements UnivariateSwitchingFunction {
     private final double ub;
 
     /**
-     * Default Constructor of the PowerSwitch.
+     * Default Constructor of the PowerSwitch: constructs a linear switch.
      */
     public PowerSwitch() {
         this(1.0, 1.0);

--- a/modules/numerics/src/main/java/ffx/numerics/switching/UnivariateFunctionFactory.java
+++ b/modules/numerics/src/main/java/ffx/numerics/switching/UnivariateFunctionFactory.java
@@ -1,0 +1,153 @@
+//******************************************************************************
+//
+// Title:       Force Field X.
+// Description: Force Field X - Software for Molecular Biophysics.
+// Copyright:   Copyright (c) Michael J. Schnieders 2001-2019.
+//
+// This file is part of Force Field X.
+//
+// Force Field X is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License version 3 as published by
+// the Free Software Foundation.
+//
+// Force Field X is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+// details.
+//
+// You should have received a copy of the GNU General Public License along with
+// Force Field X; if not, write to the Free Software Foundation, Inc., 59 Temple
+// Place, Suite 330, Boston, MA 02111-1307 USA
+//
+// Linking this library statically or dynamically with other modules is making a
+// combined work based on this library. Thus, the terms and conditions of the
+// GNU General Public License cover the whole combination.
+//
+// As a special exception, the copyright holders of this library give you
+// permission to link this library with independent modules to produce an
+// executable, regardless of the license terms of these independent modules, and
+// to copy and distribute the resulting executable under terms of your choice,
+// provided that you also meet, for each linked independent module, the terms
+// and conditions of the license of that module. An independent module is a
+// module which is not derived from or based on this library. If you modify this
+// library, you may extend this exception to your version of the library, but
+// you are not obligated to do so. If you do not wish to do so, delete this
+// exception statement from your version.
+//
+//******************************************************************************
+package ffx.numerics.switching;
+
+import java.util.Arrays;
+
+/**
+ * Static class responsible for parsing String arrays into univariate switching functions.
+ *
+ * @author Jacob M. Litman
+ * @author Michael J. Schnieders
+ */
+public class UnivariateFunctionFactory {
+    private UnivariateFunctionFactory() {
+        // Purely static class.
+    }
+
+    /**
+     * Parse an array of Strings terminating in the description of a univariate switching function.
+     *
+     * @param toks Array of Strings, terminating with the description of a function.
+     * @param offset Index of the first relevant token.
+     * @return A parsed univariate switching function.
+     */
+    public static UnivariateSwitchingFunction parseUSF(String[] toks, int offset) {
+        return parseUSF(Arrays.copyOfRange(toks, offset, toks.length));
+    }
+
+    /**
+     * Parse an array of Strings describing a univariate switching function.
+     * @param toks Descriptive Strings.
+     * @return A parsed univariate switching function.
+     */
+    public static UnivariateSwitchingFunction parseUSF(String[] toks) {
+        String selectionString = toks[0].toUpperCase().replaceAll("-", "").
+                replaceAll("_", "").replaceAll(" ", "");
+        switch(selectionString) {
+            case "BELL":
+            case "BELLCURVE":
+            case "BELLCURVESWITCH":
+                return parseBell(toks);
+            case "CONSTANT":
+            case "NONE":
+            case "FLAT":
+                return new ConstantSwitch();
+            case "LINEARDERIVATIVE":
+                return new LinearDerivativeSwitch();
+            case "MULTIPLICATIVE":
+            case "PENTICHERMITE":
+                return parseMultiplicative(toks);
+            case "POWER":
+                return parsePower(toks);
+            case "LINEAR":
+                return parseSpecificPow(1.0, toks);
+            case "QUADRATIC":
+                return parseSpecificPow(2.0, toks);
+            case "CUBIC":
+                return parseSpecificPow(3.0, toks);
+            case "TRIGONOMETRIC":
+            case "TRIG":
+            case "SINSQUARED":
+                return parseTrig(toks);
+            default:
+                throw new IllegalArgumentException(String.format(" Could not parse %s as a valid univariate switching function!", Arrays.toString(toks)));
+        }
+    }
+
+    private static BellCurveSwitch parseBell(String[] toks) {
+        double midpoint = 0.5;
+        if (toks.length > 2) {
+            midpoint = Double.parseDouble(toks[1]);
+        }
+        return new BellCurveSwitch(midpoint);
+    }
+
+    private static MultiplicativeSwitch parseMultiplicative(String[] toks) {
+        if (toks.length > 3) {
+            return new MultiplicativeSwitch(Double.parseDouble(toks[1]), Double.parseDouble(toks[2]));
+        } else {
+            return new MultiplicativeSwitch();
+        }
+
+    }
+
+    private static PowerSwitch parsePower(String[] toks) {
+        double pow = 1.0;
+        if (toks.length > 1) {
+            pow = Double.parseDouble(toks[1]);
+        }
+        double alpha = 1.0;
+        if (toks.length > 2) {
+            alpha = Double.parseDouble(toks[2]);
+        }
+        return new PowerSwitch(alpha, pow);
+    }
+
+
+
+    private static PowerSwitch parseSpecificPow(double pow, String[] toks) {
+        double alpha = 1.0;
+        if (toks.length > 1) {
+            alpha = Double.parseDouble(toks[1]);
+        }
+        return new PowerSwitch(alpha, pow);
+    }
+
+    private static SquaredTrigSwitch parseTrig(String[] toks) {
+        boolean trig = false;
+        if (toks.length > 1) {
+            trig = Boolean.parseBoolean(toks[1]);
+        }
+        if (toks.length > 2) {
+            return new SquaredTrigSwitch(Double.parseDouble(toks[2]), trig);
+        } else {
+            return new SquaredTrigSwitch(trig);
+        }
+    }
+}

--- a/modules/numerics/src/main/java/ffx/numerics/switching/UnivariateFunctionFactory.java
+++ b/modules/numerics/src/main/java/ffx/numerics/switching/UnivariateFunctionFactory.java
@@ -105,7 +105,11 @@ public class UnivariateFunctionFactory {
         if (toks.length > 2) {
             midpoint = Double.parseDouble(toks[1]);
         }
-        return new BellCurveSwitch(midpoint);
+        double width = 1.0;
+        if (toks.length > 3) {
+            width = Double.parseDouble(toks[2]);
+        }
+        return new BellCurveSwitch(midpoint, width);
     }
 
     private static MultiplicativeSwitch parseMultiplicative(String[] toks) {

--- a/modules/numerics/src/main/java/ffx/numerics/switching/UnivariateSwitchingFunction.java
+++ b/modules/numerics/src/main/java/ffx/numerics/switching/UnivariateSwitchingFunction.java
@@ -145,4 +145,6 @@ public interface UnivariateSwitchingFunction {
      * @throws java.lang.IllegalArgumentException If derivative undefined at x.
      */
     double nthDerivative(double x, int order) throws IllegalArgumentException;
+
+    // Note: implementations should have a well-defined toString() method!
 }

--- a/modules/potential/src/main/groovy/ffx/potential/groovy/test/LambdaGradient.groovy
+++ b/modules/potential/src/main/groovy/ffx/potential/groovy/test/LambdaGradient.groovy
@@ -250,6 +250,12 @@ class LambdaGradient extends PotentialScript {
 
         // Test Lambda gradient in the neighborhood of the lambda variable.
         for (int j = 0; j < 3; j++) {
+            // Reset counts.
+            ndEdLFailures = 0;
+            ndEdXFailures = 0;
+            ndEdXdLFailures = 0;
+            nd2EdL2Failures = 0;
+
             lambda = alchemical.initialLambda - lambdaMoveSize + lambdaMoveSize * j
 
             if (lambda - gradientOptions.dx < 0.0) {

--- a/modules/potential/src/main/java/ffx/potential/ForceFieldEnergy.java
+++ b/modules/potential/src/main/java/ffx/potential/ForceFieldEnergy.java
@@ -2992,7 +2992,8 @@ public class ForceFieldEnergy implements CrystalPotential, LambdaInterface {
      */
     private void setRestraintBond(Atom a1, Atom a2, double distance, double forceConstant, double flatBottom, UnivariateSwitchingFunction switchingFunction) {
         restraintBondTerm = true;
-        RestraintBond rb = new RestraintBond(a1, a2, crystal, lambdaTerm, switchingFunction);
+        boolean rbLambda = !(switchingFunction instanceof ConstantSwitch) && lambdaTerm;
+        RestraintBond rb = new RestraintBond(a1, a2, crystal, rbLambda, switchingFunction);
         int[] classes = {a1.getAtomType().atomClass, a2.getAtomType().atomClass};
         if (flatBottom != 0) {
             rb.setBondType(new BondType(classes, forceConstant, distance, BondType.BondFunction.FLAT_BOTTOM_HARMONIC, flatBottom));

--- a/modules/potential/src/main/java/ffx/potential/bonded/BondedTerm.java
+++ b/modules/potential/src/main/java/ffx/potential/bonded/BondedTerm.java
@@ -224,6 +224,15 @@ public abstract class BondedTerm extends MSNode implements BondedEnergy, Compara
     }
 
     /**
+     * Check if this BondedTerm is lambda-sensitive (e.g. a softcored dihedral).
+     *
+     * @return True if Lambda affects the energy of this term.
+     */
+    public boolean isLambdaScaled() {
+        return false;
+    }
+
+    /**
      * Check if this BondedTerm is constrained.
      *
      * @return If constrained.

--- a/modules/potential/src/main/java/ffx/potential/bonded/RestraintBond.java
+++ b/modules/potential/src/main/java/ffx/potential/bonded/RestraintBond.java
@@ -132,11 +132,17 @@ public class RestraintBond extends BondedTerm implements LambdaInterface {
         return lambda;
     }
 
+    @Override
+    public boolean isLambdaScaled() {
+        return lambdaTerm;
+    }
+
     /**
      * {@inheritDoc}
      */
     @Override
     public double getdEdL() {
+
         return dEdL;
     }
 
@@ -748,11 +754,9 @@ public class RestraintBond extends BondedTerm implements LambdaInterface {
                 "Restraint-Bond", atoms[0].getIndex(), atoms[0].getAtomType().name,
                 atoms[1].getIndex(), atoms[1].getAtomType().name,
                 bondType.distance, value, energy));
-        // Below would print atom name instead of atom type name (sometimes more informative), and maintain more consistent columns.
-        /*logger.info(String.format(" %s %6d-%-4s %6d-%-4s %6.4f  %6.4f  %10.4f",
-                "Restraint-Bond", atoms[0].getIndex(), atoms[0].getName(),
-                atoms[1].getIndex(), atoms[1].getName(),
-                bondType.distance, value, energy));*/
+        if (!(switchingFunction instanceof  ConstantSwitch)) {
+            logger.info(String.format(" Switching function (lambda dependence): %s", switchingFunction.toString()));
+        }
     }
 
     @Override

--- a/modules/potential/src/main/java/ffx/potential/bonded/RestraintBond.java
+++ b/modules/potential/src/main/java/ffx/potential/bonded/RestraintBond.java
@@ -84,9 +84,10 @@ public class RestraintBond extends BondedTerm implements LambdaInterface {
     private double switchVal = 1.0;
     private double switchdUdL = 1.0;
     private double switchd2UdL2 = 1.0;
-    private double restraintLambdaStart = 0.75;
+    private final double restraintLambdaStart = 0.75;
     private final double restraintLambdaStop = 1.00;
-    private double restraintLambdaWindow = (restraintLambdaStop - restraintLambdaStart);
+    private final double restraintLambdaWindow = (restraintLambdaStop - restraintLambdaStart);
+    private final double rlwInv = 1.0 / restraintLambdaWindow;
     private final UnivariateSwitchingFunction switchingFunction;
     private double dEdL = 0.0;
     private double d2EdL2 = 0.0;
@@ -100,15 +101,21 @@ public class RestraintBond extends BondedTerm implements LambdaInterface {
         this.lambda = lambda;
         if (lambdaTerm) {
             if (lambda < restraintLambdaStart) {
+                restraintLambda = 0.0;
+                switchVal = 0.0;
+                switchdUdL = 0;
+                switchd2UdL2 = 0;
+            } else if (lambda > restraintLambdaStop) {
                 restraintLambda = 1.0;
                 switchVal = 1.0;
                 switchdUdL = 0;
                 switchd2UdL2 = 0;
+            } else {
+                restraintLambda = (lambda - restraintLambdaStart) / restraintLambdaWindow;
+                switchVal = switchingFunction.valueAt(restraintLambda);
+                switchdUdL = rlwInv * switchingFunction.firstDerivative(restraintLambda);
+                switchd2UdL2 = rlwInv * rlwInv * switchingFunction.secondDerivative(restraintLambda);
             }
-            restraintLambda = 1.0 - (lambda - restraintLambdaStart) / restraintLambdaWindow;
-            switchVal = switchingFunction.valueAt(restraintLambda);
-            switchdUdL = switchingFunction.firstDerivative(restraintLambda);
-            switchd2UdL2 = switchingFunction.secondDerivative(restraintLambda);
         } else {
             restraintLambda = 1.0;
             switchVal = 1.0;


### PR DESCRIPTION
How things should work as of this commit:

Without dual-topology, everything is calculated as expected. If it's lambda-scaled internally, that happens normally.

During dual-topology, terms get sorted into these categories:
1) Shared bonded & nonbonded terms: Calculated as L*(term) in one topology, and as (1-L)*(term) in the second, complementing back to a full-strength term.
2) Unshared nonbonded terms: calculated as L*(term) in the first topology.
3) Unshared but lambda-independent bonded terms: calculated as L*(term) during the main evaluation, and then recalculated as (1-L)*(term) with lambdaBondedTerms true, with the energy placed into restraintEnergy.
4) Unshared, lambda-dependent bonded terms (including some RestraintBonds): calculated as L*(term) in the first topology.

As such, the only time a term gets internally complemented (brought back to full-strength via the lambdaBondedTerms calculation) is when it is a non-lambda-scaled bonded term with at least one atom not shared in the other topology.